### PR TITLE
feat: migrate instructions.md to AGENTS.md with versioned marker

### DIFF
--- a/.opencode/.gitignore
+++ b/.opencode/.gitignore
@@ -1,4 +1,3 @@
-instructions.md
 command/
 .engram-*
 scripts/

--- a/.opencode/claude-warning.ts
+++ b/.opencode/claude-warning.ts
@@ -1,0 +1,29 @@
+/**
+ * Engram — CLAUDE.md Collision Warning
+ * ======================================
+ *
+ * OpenCode's instruction discovery breaks on the first filename match in the
+ * ancestor chain (instruction.ts:64-68, :122-133). When AGENTS.md exists at
+ * the project root, any existing CLAUDE.md is silently suppressed — the model
+ * never sees it.
+ *
+ * This module logs a visible warning during selfExtract so the user knows
+ * their CLAUDE.md rules are no longer reaching the model and can take action.
+ *
+ * CONTEXT.md is also in instructionFiles but is deprecated — no warning is
+ * emitted for it. The fix for both is the same: consolidate rules into
+ * AGENTS.md or remove it.
+ *
+ * Called by: install.ts → selfExtract (project-level installs only).
+ */
+
+import { existsSync } from "node:fs"
+import { resolve } from "node:path"
+
+const WARNING = "Engram: WARNING — CLAUDE.md exists here and will be suppressed by AGENTS.md (first match wins in instruction discovery). Review both files."
+
+export function warnClaudeMdCollision(projectRoot: string, log: (msg: string) => void) {
+  if (existsSync(resolve(projectRoot, "CLAUDE.md"))) {
+    log(WARNING)
+  }
+}

--- a/.opencode/index.ts
+++ b/.opencode/index.ts
@@ -26,7 +26,7 @@
  *
  * Generated (always overwritten on extract):
  *   command/  → command/{learn,review-loop,coach}.md
- *   instructions.md → file path for cfg.instructions
+ *   AGENTS.md → versioned marker block (project root or ~/.config/opencode/)
  *   .engram-version.jsonc → idempotency: {version, previous, installed_at, source}
  *   .engram-update.jsonc  → per-category diff manifest (only on version bump)
  *
@@ -53,9 +53,25 @@
  *      Shape note: targets the OpenCode v1 SDK config layer (skills.paths,
  *      command singular, agent singular). v2 uses skills: string[] and
  *      commands: plural. The bridge shapes are intentional.
- *   3. cfg.instructions = {target}/instructions.md — file path.
- *
  *   After first exec: bridge off, disk discovery handles everything.
+ *
+ * AGENTS.md (no bridge needed)
+ * ------------------------------
+ *
+ *   AGENTS.md is written directly to disk by selfExtract. No cfg.instructions
+ *   registration is required because both V1 and V2 discover it natively:
+ *
+ *     V1 (HTTP API / CLI) — fs.findUp("AGENTS.md") every request.
+ *     V2 (InstructionContext) — fs.up({ targets: ["AGENTS.md"] }) every turn.
+ *
+ *   The file is re-read from disk on every LLM request — no bridge, no cache,
+ *   no restart needed. Changes or creation take effect immediately.
+ *
+ *   selfExtract also:
+ *     - Adds AGENTS.md to .git/info/exclude so the file is never committed
+ *       (per-repo local gitignore, no hook, no working-tree mutation).
+ *     - Warns if CLAUDE.md exists at the project root — AGENTS.md takes
+ *       discovery priority over CLAUDE.md (first filename match wins).
  *
  * Update system (update.ts)
  * -------------------------
@@ -138,10 +154,11 @@
  * -----------------------------
  *
  *   docs/ from extract        → end users don't need internal docs.
- *   cfg.references            → all paths local; instructions.md covers it.
+ *   cfg.references            → all paths local; AGENTS.md covers it.
  *   cfg.permission            → no external paths remain post-extract.
  *   cfg.{skills,commands,agents} → disk discovery (bridge on first exec).
- *   inline instructions       → file path to instructions.md.
+ *   cfg.instructions push     → dropped — V1 and V2 both discover AGENTS.md
+ *                               natively (re-read from disk every request).
  *   copyDir / cpSync          → copyMissing (never overwrite user files).
  *
  * Known OpenCode bug
@@ -159,6 +176,7 @@ import { createSessionStartHooks } from "../hooks/session-start.js"
 import { createShellEnvHook } from "../hooks/shell-env.js"
 import { detectInstallType } from "./install-type.js"
 import { selfExtract, getExtractTarget, getVERSION } from "./install.js"
+import { createPluginLogger } from "./logger.js"
 import { engramUpdateTool } from "./update-tool.js"
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
@@ -205,7 +223,7 @@ Tool: Read
 Path: $TARGET/.engram-update.jsonc
 
 The Engram system consists of:
-  instructions.md    — model behavioral rules
+  AGENTS.md         — model behavioral rules (project root or global)
   skills/            — skill definitions (learn, review, coach)
   agents/            — subagent definitions (curriculum-architect, engram-assessor, artifact-smith)
   scripts/           — deterministic engine (engram.py)
@@ -298,7 +316,7 @@ STOP.
 ## Constraints — MUST follow
 - Use Read tool for the manifest. NEVER use Glob.
 - Do NOT use Bash for file deletion or manifest updates. Use the engram_update tool instead.
-- Do NOT delete instructions.md or scripts/engram.py directly.
+- Do NOT delete AGENTS.md or scripts/engram.py directly.
 - Do NOT add, modify, or rename any file.
 - If a category.skipped array is empty, skip that category silently.
 - Do NOT output text beyond what each step prescribes.`
@@ -317,7 +335,8 @@ export const server: Plugin = async ({ client, $, directory }) => {
       let target: string
       let freshlyExtracted = false
       if (type === "npm") {
-        const result = selfExtract(root, cwd, getVERSION(root))
+        const logger = createPluginLogger(client)
+        const result = selfExtract(root, cwd, getVERSION(root), logger)
         target = result.target
         freshlyExtracted = result.freshlyExtracted
       } else {
@@ -344,12 +363,6 @@ export const server: Plugin = async ({ client, $, directory }) => {
       }
       cfg.tools = cfg.tools || {}
       cfg.tools["engram_update"] = existsSync(resolve(target, ".engram-update.jsonc"))
-
-      const instructionsFile = resolve(target, "instructions.md")
-      if (existsSync(instructionsFile)) {
-        cfg.instructions = cfg.instructions || []
-        cfg.instructions.push(instructionsFile)
-      }
       } catch {}
     },
     tool: {

--- a/.opencode/install.ts
+++ b/.opencode/install.ts
@@ -6,17 +6,20 @@
  * copyMissing() never overwrites existing files — preserves user edits across updates.
  *
  * Extraction (DIRS): skills/, agents/, scripts/ (new files only, never overwrite)
- * Generated (always overwritten): instructions.md, command/, .engram-version.jsonc
+ * Generated (versioned marker block): AGENTS.md (project root or global)
+ * Generated (always overwritten): command/, .engram-version.jsonc
  *
  * Version bump detection via .engram-version.jsonc idempotency guard.
  * On version bump, writes .engram-update.jsonc for /engram-update pseudo-command.
  * On fresh install, no manifest — bridge registers agents/commands/skills in config hook.
  */
 
-import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync, copyFileSync } from "node:fs"
-import { resolve } from "node:path"
+import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync, copyFileSync, unlinkSync } from "node:fs"
+import { resolve, basename } from "node:path"
+import { execSync } from "node:child_process"
 import { parseFrontmatter } from "./parse-frontmatter.js"
 import { writeUpdateManifest } from "./update.js"
+import { warnClaudeMdCollision } from "./claude-warning.js"
 
 /** Directory categories copied by selfExtract. docs/ deliberately excluded. */
 const DIRS = ["skills", "agents", "scripts"]
@@ -45,6 +48,171 @@ The following references are available and resolve to the extracted copy in .ope
 - **engram-curriculum-architect** — decomposes topics into concept DAGs
 - **engram-artifact-smith** — builds interactive HTML explorables for threshold concepts
 `
+
+// ---------------------------------------------------------------------------
+// AGENTS.md helpers — versioned marker-based prepend (option B)
+// ---------------------------------------------------------------------------
+
+const MARKER_OPEN = "<!-- engram v"
+const MARKER_CLOSE = "<!-- /engram -->"
+const MARKER_RE = /^<!-- engram v(.+?) -->$/m
+
+function buildEngramBlock(version: string): string {
+  return `${MARKER_OPEN}${version} -->\n${INSTRUCTIONS_TEXT}${MARKER_CLOSE}\n`
+}
+
+function findEngramBlock(content: string): { version: string; start: number; end: number } | null {
+  const match = content.match(MARKER_RE)
+  if (!match) return null
+  const version = match[1]
+  const start = match.index!
+  const closeIdx = content.indexOf(MARKER_CLOSE, start + match[0].length)
+  if (closeIdx === -1) return null
+  return { version, start, end: closeIdx + MARKER_CLOSE.length }
+}
+
+/** Resolves the AGENTS.md path based on extraction target.
+ *  Project-level (target basename is ".opencode") → {parent}/AGENTS.md
+ *  Global (target is ~/.config/opencode) → {target}/AGENTS.md */
+export function resolveAgentsPath(target: string): string {
+  if (basename(target) === ".opencode") {
+    return resolve(target, "..", "AGENTS.md")
+  }
+  return resolve(target, "AGENTS.md")
+}
+
+/**
+ * Writes or prepends the Engram instruction block to AGENTS.md.
+ *
+ * Returns true if the file was created by Engram (didn't exist before),
+ * false otherwise. Used to conditionally install git exclude.
+ *
+ * - File absent → create with versioned marker block (returns true).
+ * - Block present with matching version → no-op (idempotent).
+ * - Block present with different version → replace old block, preserve user content below.
+ * - Block absent → prepend new block at top, preserve existing content.
+ *
+ * No data loss — user content below the block is never modified.
+ */
+export function writeOrPrependAgentsMd(target: string, version: string): boolean {
+  const agentsPath = resolveAgentsPath(target)
+  const block = buildEngramBlock(version)
+
+  if (!existsSync(agentsPath)) {
+    writeFileSync(agentsPath, block)
+    return true
+  }
+
+  const existing = readFileSync(agentsPath, "utf-8")
+  const found = findEngramBlock(existing)
+
+  if (found && found.version === version) return false
+
+  if (found) {
+    const before = existing.slice(0, found.start)
+    const after = existing.slice(found.end).replace(/^\n+/, "")
+    writeFileSync(agentsPath, before + block + (after ? "\n\n" + after : ""))
+  } else {
+    writeFileSync(agentsPath, existing.trim() ? block + "\n\n" + existing : block)
+  }
+  return false
+}
+
+/**
+ * Installs git infrastructure for AGENTS.md lifecycle management.
+ *
+ * Three mechanisms, each covering a different scenario:
+ *
+ * 1. SMUDGE/CLEAN FILTER (.git/config)
+ *      clean — strips the Engram block on git add (git stores only user content).
+ *      smudge — prepends the Engram block on git checkout (disk always has it).
+ *      Guarded: if scripts don't exist, falls back to cat (harmless passthrough).
+ *      Depends on python3 on PATH — skipped with a warning if absent.
+ *
+ * 2. PATH ATTRIBUTES (.git/info/attributes)
+ *      Assigns AGENTS.md filter=engram so git knows to apply the filter.
+ *      Local (not versioned), affects only this clone.
+ *
+ * 3. LOCAL EXCLUDE (.git/info/exclude)
+ *      Prevents git from tracking an otherwise-empty AGENTS.md (no user
+ *      content yet) and .engram-* internal files. Combined with the filter,
+ *      the file is still tracked if the user explicitly git add --force
+ *      (filter strips the block). Local (not versioned), affects only this clone.
+ *      Only written when engramCreated is true (file didn't exist before).
+ *
+ * Each mechanism is checked independently — partial-state repair is supported.
+ * Each mechanism is wrapped in try/catch — a failure in one does not block the others.
+ * Only operates on project-level installs (where .git/config exists).
+ *
+ * Uninstall note: removing Engram leaves the filter config in .git/config,
+ * .git/info/attributes, and .git/info/exclude. Without the scripts, the
+ * filter falls back to cat — harmless. To fully clean up, remove the
+ * [filter "engram"] section from .git/config and the engram lines from
+ * .git/info/attributes and .git/info/exclude.
+ */
+function installGitFilter(projectRoot: string, engramCreated: boolean, log: (msg: string) => void) {
+  const gitConfig = resolve(projectRoot, ".git", "config")
+  if (!existsSync(gitConfig)) return
+
+  // Skip git filter when python3 is not available — the clean/smudge scripts
+  // depend on it. Without the filter, every git add/checkout would print
+  // "python3: not found" errors and leak the block.
+  try { execSync("python3 --version", { stdio: "ignore" }) } catch {
+    log("Engram: WARNING — python3 not found, skipping git filter. AGENTS.md will not be filtered.")
+    return
+  }
+
+  const infoDir = resolve(projectRoot, ".git", "info")
+
+  // 1. SMUDGE/CLEAN FILTER — check independently, no early return
+  try {
+    const configContent = readFileSync(gitConfig, "utf-8")
+    if (!configContent.includes('[filter "engram"]')) {
+      const filterBlock = `[filter "engram"]
+\tclean = "if [ -f .opencode/scripts/opencode-engram-clean ]; then python3 .opencode/scripts/opencode-engram-clean; else cat; fi"
+\tsmudge = "if [ -f .opencode/scripts/opencode-engram-smudge ]; then python3 .opencode/scripts/opencode-engram-smudge; else cat; fi"
+`
+      writeFileSync(gitConfig, configContent.trimEnd() + "\n" + filterBlock)
+    }
+  } catch {}
+
+  // 2. PATH ATTRIBUTES — check independently
+  try {
+    const gitAttrsInfo = resolve(infoDir, "attributes")
+    if (existsSync(gitAttrsInfo)) {
+      const attrs = readFileSync(gitAttrsInfo, "utf-8")
+      if (!attrs.includes("AGENTS.md filter=engram")) {
+        writeFileSync(gitAttrsInfo, attrs.trimEnd() + "\nAGENTS.md filter=engram\n")
+      }
+    } else {
+      mkdirSync(infoDir, { recursive: true })
+      writeFileSync(gitAttrsInfo, "AGENTS.md filter=engram\n")
+    }
+  } catch {}
+
+  // 3. LOCAL EXCLUDE — only when engram created AGENTS.md (avoid hiding user-authored files)
+  if (!engramCreated) return
+
+  try {
+    const excludeFile = resolve(infoDir, "exclude")
+    if (existsSync(excludeFile)) {
+      const exclude = readFileSync(excludeFile, "utf-8")
+      const hasAgents = exclude.split("\n").some(l => l.trim() === "AGENTS.md")
+      const hasDotFiles = exclude.split("\n").some(l => l.trim() === ".engram-*")
+      if (!hasAgents || !hasDotFiles) {
+        const lines: string[] = []
+        if (!hasDotFiles) lines.push("# Engram internal files\n.engram-*")
+        if (!hasAgents) lines.push("# Engram plugin instructions\nAGENTS.md")
+        writeFileSync(excludeFile, exclude.trimEnd() + "\n" + lines.join("\n") + "\n")
+      }
+    } else {
+      mkdirSync(infoDir, { recursive: true })
+      writeFileSync(excludeFile, "# Engram internal files\n.engram-*\n# Engram plugin instructions\nAGENTS.md\n")
+    }
+  } catch {}
+
+  log("Engram: installed git filter (clean+smudge) for AGENTS.md")
+}
 
 /** Extracts the version string from package.json. Falls back to "0.0.0". */
 export function getVERSION(root: string): string {
@@ -183,7 +351,7 @@ function generateCommands(target: string, log: (msg: string) => void) {
  * 1. Version check → skip if same
  * 2. copyMissing skills/, agents/, scripts/ (new files only)
  * 3. Transform agents to OpenCode YAML (mode: subagent, hidden: true)
- * 4. Generate instructions.md, command/ (always overwritten)
+ * 4. Generate AGENTS.md (versioned marker block), command/ (always overwritten)
  * 5. Write .engram-version.jsonc with version + previous
  * 6. On version bump: writeUpdateManifest() → .engram-update.jsonc
  *
@@ -219,7 +387,15 @@ export function selfExtract(packageRoot: string, directory: string, version: str
       }
     }
 
-    writeFileSync(resolve(target, "instructions.md"), INSTRUCTIONS_TEXT)
+    const engramCreated = writeOrPrependAgentsMd(target, version)
+
+    const smudgeTemplate = resolve(target, ".engram-smudge-template")
+    writeFileSync(smudgeTemplate, buildEngramBlock(version))
+
+    const legacyInstructions = resolve(target, "instructions.md")
+    if (existsSync(legacyInstructions)) {
+      unlinkSync(legacyInstructions)
+    }
 
     generateCommands(target, log)
 
@@ -233,6 +409,16 @@ export function selfExtract(packageRoot: string, directory: string, version: str
 
     if (prevVersion) {
       writeUpdateManifest(packageRoot, target, prevVersion, version)
+    }
+
+    if (basename(target) === ".opencode") {
+      const projectRoot = resolve(target, "..")
+      try {
+        installGitFilter(projectRoot, engramCreated, log)
+      } catch {}
+      try {
+        warnClaudeMdCollision(projectRoot, log)
+      } catch {}
     }
 
     return { target, freshlyExtracted: !prevVersion, prevVersion }

--- a/.opencode/logger.ts
+++ b/.opencode/logger.ts
@@ -1,0 +1,31 @@
+/**
+ * Engram — Plugin Logger
+ * ========================
+ *
+ * Creates a logger function for selfExtract and other plugin operations.
+ *
+ * Writes structured logs to OpenCode's server-side log via client.app.log().
+ * Shows TUI toasts for warnings via client.tui.showToast().
+ *
+ * Matches the (msg: string) => void signature expected by selfExtract.
+ */
+
+export function createPluginLogger(client: any): (msg: string) => void {
+  function writeLog(level: "debug" | "info" | "warn" | "error", message: string) {
+    try {
+      client.app.log({ service: "engram", level, message })
+    } catch {}
+  }
+
+  return (msg: string) => {
+    const level = msg.includes("WARNING") ? "warn" : "info"
+    writeLog(level, msg)
+    if (level === "warn") {
+      try {
+        client.tui.showToast({
+          body: { title: "Engram", message: msg, variant: "warning", duration: 15000 },
+        }).catch(() => {})
+      } catch {}
+    }
+  }
+}

--- a/__tests__/claude-warning.test.ts
+++ b/__tests__/claude-warning.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { tmpdir } from "node:os"
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { warnClaudeMdCollision } from "../.opencode/claude-warning"
+import { selfExtract } from "../.opencode/install"
+
+describe("warnClaudeMdCollision (unit)", () => {
+  let tmp: string
+
+  beforeEach(() => { tmp = mkdtempSync(resolve(tmpdir(), "engram-test-")) })
+  afterEach(() => rmSync(tmp, { recursive: true }))
+
+  it("logs warning when CLAUDE.md exists", () => {
+    writeFileSync(resolve(tmp, "CLAUDE.md"), "# rules")
+    const messages: string[] = []
+    warnClaudeMdCollision(tmp, (m) => messages.push(m))
+    expect(messages.length).toBe(1)
+    expect(messages[0]).toContain("WARNING")
+    expect(messages[0]).toContain("CLAUDE.md")
+    expect(messages[0]).toContain("suppressed")
+  })
+
+  it("does NOT log when CLAUDE.md is absent", () => {
+    const messages: string[] = []
+    warnClaudeMdCollision(tmp, (m) => messages.push(m))
+    expect(messages.length).toBe(0)
+  })
+
+  it("does NOT log when directory is empty", () => {
+    const messages: string[] = []
+    warnClaudeMdCollision(tmp, (m) => messages.push(m))
+    expect(messages.length).toBe(0)
+  })
+
+  it("does NOT log for CLAUDE.md with different case on case-sensitive fs", () => {
+    writeFileSync(resolve(tmp, "claude.md"), "# rules")
+    const messages: string[] = []
+    warnClaudeMdCollision(tmp, (m) => messages.push(m))
+    expect(messages.length).toBe(0)
+  })
+
+  it("logs warning for a directory named CLAUDE.md (existsSync true)", () => {
+    mkdirSync(resolve(tmp, "CLAUDE.md"))
+    const messages: string[] = []
+    warnClaudeMdCollision(tmp, (m) => messages.push(m))
+    expect(messages.length).toBe(1)
+    expect(messages[0]).toContain("WARNING")
+  })
+})
+
+describe("warnClaudeMdCollision (integration via selfExtract)", () => {
+  let tmp: string
+  let pkg: string
+
+  beforeEach(() => {
+    tmp = mkdtempSync(resolve(tmpdir(), "engram-test-"))
+    writeFileSync(resolve(tmp, "opencode.jsonc"), "{}")
+    mkdirSync(resolve(tmp, ".git"), { recursive: true })
+    writeFileSync(resolve(tmp, ".git", "config"), "[core]\n\trepositoryformatversion = 0\n")
+    pkg = resolve(tmp, "pkg")
+    mkdirSync(resolve(pkg, "skills"), { recursive: true })
+    writeFileSync(resolve(pkg, "skills", "SKILL.md"), "skill")
+    mkdirSync(resolve(pkg, "agents"), { recursive: true })
+    writeFileSync(resolve(pkg, "agents", "agent.md"), "agent")
+    mkdirSync(resolve(pkg, "scripts"), { recursive: true })
+    writeFileSync(resolve(pkg, "scripts", "engram.py"), "script")
+    writeFileSync(resolve(pkg, "package.json"), JSON.stringify({ version: "1.0.2" }))
+  })
+  afterEach(() => rmSync(tmp, { recursive: true }))
+
+  it("logs CLAUDE.md warning during selfExtract when CLAUDE.md exists", () => {
+    writeFileSync(resolve(tmp, "CLAUDE.md"), "# rules")
+    const target = resolve(tmp, ".opencode")
+    mkdirSync(target, { recursive: true })
+    writeFileSync(resolve(target, ".engram-version.jsonc"), JSON.stringify({ version: "0.9.0" }))
+
+    const messages: string[] = []
+    selfExtract(pkg, tmp, "1.0.2", (m) => messages.push(m))
+
+    expect(messages.some((m) => m.includes("WARNING") && m.includes("CLAUDE.md"))).toBe(true)
+  })
+
+  it("does NOT log CLAUDE.md warning during selfExtract when CLAUDE.md absent", () => {
+    const target = resolve(tmp, ".opencode")
+    mkdirSync(target, { recursive: true })
+    writeFileSync(resolve(target, ".engram-version.jsonc"), JSON.stringify({ version: "0.9.0" }))
+
+    const messages: string[] = []
+    selfExtract(pkg, tmp, "1.0.2", (m) => messages.push(m))
+
+    expect(messages.every((m) => !m.includes("CLAUDE.md"))).toBe(true)
+  })
+
+  it("does NOT log CLAUDE.md warning on same-version (no selfExtract)", () => {
+    writeFileSync(resolve(tmp, "CLAUDE.md"), "# rules")
+    const target = resolve(tmp, ".opencode")
+    mkdirSync(target, { recursive: true })
+    writeFileSync(resolve(target, ".engram-version.jsonc"), JSON.stringify({ version: "1.0.2" }))
+
+    const messages: string[] = []
+    selfExtract(pkg, tmp, "1.0.2", (m) => messages.push(m))
+
+    expect(messages.every((m) => !m.includes("CLAUDE.md"))).toBe(true)
+  })
+})

--- a/__tests__/git-filter.test.ts
+++ b/__tests__/git-filter.test.ts
@@ -1,0 +1,480 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { tmpdir } from "node:os"
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync, copyFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { execSync } from "node:child_process"
+import { selfExtract } from "../.opencode/install"
+
+describe("git filter integration", () => {
+  let tmp: string
+  let pkg: string
+
+  beforeEach(() => {
+    tmp = mkdtempSync(resolve(tmpdir(), "engram-test-"))
+    writeFileSync(resolve(tmp, "opencode.jsonc"), "{}")
+    mkdirSync(resolve(tmp, ".git"), { recursive: true })
+    writeFileSync(resolve(tmp, ".git", "config"), "[core]\n\trepositoryformatversion = 0\n")
+    pkg = resolve(tmp, "pkg")
+    mkdirSync(resolve(pkg, "skills"), { recursive: true })
+    writeFileSync(resolve(pkg, "skills", "SKILL.md"), "skill")
+    mkdirSync(resolve(pkg, "agents"), { recursive: true })
+    writeFileSync(resolve(pkg, "agents", "agent.md"), "agent")
+    mkdirSync(resolve(pkg, "scripts"), { recursive: true })
+    writeFileSync(resolve(pkg, "scripts", "engram.py"), "script")
+    writeFileSync(resolve(pkg, "package.json"), JSON.stringify({ version: "1.0.2" }))
+  })
+  afterEach(() => rmSync(tmp, { recursive: true }))
+
+  it("installs git filter and .git/info/attributes on selfExtract", () => {
+    const target = resolve(tmp, ".opencode")
+    mkdirSync(target, { recursive: true })
+    writeFileSync(resolve(target, ".engram-version.jsonc"), JSON.stringify({ version: "0.9.0" }))
+
+    selfExtract(pkg, tmp, "1.0.2")
+
+    const gitConfig = readFileSync(resolve(tmp, ".git", "config"), "utf-8")
+    expect(gitConfig).toContain('[filter "engram"]')
+    expect(gitConfig).toContain("opencode-engram-clean")
+    expect(gitConfig).toContain("opencode-engram-smudge")
+
+    const gitattrs = readFileSync(resolve(tmp, ".git", "info", "attributes"), "utf-8")
+    expect(gitattrs).toContain("AGENTS.md filter=engram")
+
+    const gitExclude = readFileSync(resolve(tmp, ".git", "info", "exclude"), "utf-8")
+    expect(gitExclude).toContain("AGENTS.md")
+    expect(gitExclude).toContain(".engram-*")
+  })
+
+  it("does NOT duplicate filter on second extract", () => {
+    const target = resolve(tmp, ".opencode")
+    mkdirSync(target, { recursive: true })
+    writeFileSync(resolve(target, ".engram-version.jsonc"), JSON.stringify({ version: "0.9.0" }))
+
+    selfExtract(pkg, tmp, "1.0.2")
+    const config1 = readFileSync(resolve(tmp, ".git", "config"), "utf-8")
+    writeFileSync(resolve(target, ".engram-version.jsonc"), JSON.stringify({ version: "0.9.1" }))
+    selfExtract(pkg, tmp, "1.0.3")
+    const config2 = readFileSync(resolve(tmp, ".git", "config"), "utf-8")
+
+    expect(config1).toBe(config2)
+  })
+
+  it("does NOT duplicate exclude and attributes on second extract", () => {
+    const target = resolve(tmp, ".opencode")
+    mkdirSync(target, { recursive: true })
+    writeFileSync(resolve(target, ".engram-version.jsonc"), JSON.stringify({ version: "0.9.0" }))
+
+    selfExtract(pkg, tmp, "1.0.2")
+    const exclude1 = readFileSync(resolve(tmp, ".git", "info", "exclude"), "utf-8")
+    const attrs1 = readFileSync(resolve(tmp, ".git", "info", "attributes"), "utf-8")
+
+    writeFileSync(resolve(target, ".engram-version.jsonc"), JSON.stringify({ version: "0.9.1" }))
+    selfExtract(pkg, tmp, "1.0.3")
+    const exclude2 = readFileSync(resolve(tmp, ".git", "info", "exclude"), "utf-8")
+    const attrs2 = readFileSync(resolve(tmp, ".git", "info", "attributes"), "utf-8")
+
+    expect(exclude1).toBe(exclude2)
+    expect(attrs1).toBe(attrs2)
+  })
+
+  it("creates .git/info/attributes and appends to existing .git/info/exclude", () => {
+    const target = resolve(tmp, ".opencode")
+    mkdirSync(target, { recursive: true })
+    writeFileSync(resolve(target, ".engram-version.jsonc"), JSON.stringify({ version: "0.9.0" }))
+
+    const infoDir = resolve(tmp, ".git", "info")
+    mkdirSync(infoDir, { recursive: true })
+    const existingExclude = "# default git exclusion\nsome-other-file\n"
+    writeFileSync(resolve(infoDir, "exclude"), existingExclude)
+
+    selfExtract(pkg, tmp, "1.0.2")
+
+    expect(existsSync(resolve(infoDir, "attributes"))).toBe(true)
+    const attrs = readFileSync(resolve(infoDir, "attributes"), "utf-8")
+    expect(attrs).toContain("AGENTS.md filter=engram")
+
+    const exclude = readFileSync(resolve(infoDir, "exclude"), "utf-8")
+    expect(exclude).toContain("AGENTS.md")
+    expect(exclude).toContain("some-other-file")
+    expect(exclude.indexOf("some-other-file")).toBeLessThan(exclude.indexOf("AGENTS.md"))
+  })
+
+  it("does not crash when .git/config is absent (no git repo)", () => {
+    const tmp2 = mkdtempSync(resolve(tmpdir(), "engram-test-"))
+    try {
+      writeFileSync(resolve(tmp2, "opencode.jsonc"), "{}")
+      const pkg2 = resolve(tmp2, "pkg")
+      mkdirSync(resolve(pkg2, "skills"), { recursive: true })
+      writeFileSync(resolve(pkg2, "skills", "SKILL.md"), "skill")
+      mkdirSync(resolve(pkg2, "agents"), { recursive: true })
+      writeFileSync(resolve(pkg2, "agents", "agent.md"), "agent")
+      mkdirSync(resolve(pkg2, "scripts"), { recursive: true })
+      writeFileSync(resolve(pkg2, "scripts", "engram.py"), "script")
+      writeFileSync(resolve(pkg2, "package.json"), JSON.stringify({ version: "1.0.2" }))
+
+      const target = resolve(tmp2, ".opencode")
+      mkdirSync(target, { recursive: true })
+      writeFileSync(resolve(target, ".engram-version.jsonc"), JSON.stringify({ version: "0.9.0" }))
+
+      expect(() => selfExtract(pkg2, tmp2, "1.0.2")).not.toThrow()
+    } finally {
+      rmSync(tmp2, { recursive: true })
+    }
+  })
+
+  it("filter values are double-quoted (semicolon-safe)", () => {
+    const target = resolve(tmp, ".opencode")
+    mkdirSync(target, { recursive: true })
+    writeFileSync(resolve(target, ".engram-version.jsonc"), JSON.stringify({ version: "0.9.0" }))
+
+    selfExtract(pkg, tmp, "1.0.2")
+
+    const gitConfig = readFileSync(resolve(tmp, ".git", "config"), "utf-8")
+    // Values must be double-quoted to survive git's ; comment parsing
+    expect(gitConfig).toMatch(/clean = "if \[/)
+    expect(gitConfig).toMatch(/smudge = "if \[/)
+    expect(gitConfig).toMatch(/else cat; fi"/)
+  })
+
+  /**
+   * 1. — exclude is conditional on engramCreated.
+   *
+   * When AGENTS.md already existed (user-authored), writeOrPrependAgentsMd
+   * returns false and installGitFilter skips the exclude entry. Without
+   * this, a user's own AGENTS.md vanishes from git status and they never
+   * notice their rules aren't shared.
+   */
+  it("1. exclude NOT written when AGENTS.md already existed before extract", () => {
+
+    const target = resolve(tmp, ".opencode")
+    mkdirSync(target, { recursive: true })
+    writeFileSync(resolve(target, ".engram-version.jsonc"), JSON.stringify({ version: "0.9.0" }))
+
+    // Pre-create AGENTS.md (simulates user-authored file)
+    writeFileSync(resolve(tmp, "AGENTS.md"), "# My custom rules\nuser content\n")
+
+    selfExtract(pkg, tmp, "1.0.2")
+
+    const excludePath = resolve(tmp, ".git", "info", "exclude")
+    if (existsSync(excludePath)) {
+      const exclude = readFileSync(excludePath, "utf-8")
+      expect(exclude).not.toContain("AGENTS.md")
+    }
+  })
+
+  /**
+   * 2. — EACCES on .git/config does not abort the full extract.
+   *
+   * If .git/config is read-only (e.g., root-owned repo), the git filter
+   * installation must fail gracefully without stopping generateCommands
+   * or the version-file write. Both installGitFilter and
+   * warnClaudeMdCollision are wrapped in individual try/catch and run
+   * after the version write.
+   */
+  it("2. read-only .git/config does not abort the extract", () => {
+    const target = resolve(tmp, ".opencode")
+    mkdirSync(target, { recursive: true })
+    writeFileSync(resolve(target, ".engram-version.jsonc"), JSON.stringify({ version: "0.9.0" }))
+
+    // Make .git/config read-only
+    const { chmodSync } = require("node:fs")
+    chmodSync(resolve(tmp, ".git", "config"), 0o444)
+
+    try {
+      // Extract should succeed — commands and version file are written
+      selfExtract(pkg, tmp, "1.0.2")
+      expect(existsSync(resolve(target, "command", "learn.md"))).toBe(true)
+      expect(existsSync(resolve(target, ".engram-version.jsonc"))).toBe(true)
+    } finally {
+      chmodSync(resolve(tmp, ".git", "config"), 0o644)
+    }
+  })
+
+  /**
+   * 3. — partial-state repair.
+   *
+   * Each git mechanism (filter config, path attributes, local exclude)
+   * is checked independently. A user who deletes .git/info/attributes
+   * after the first extract gets it restored on the next — no early
+   * return when [filter "engram"] already exists.
+   */
+  it("3. filter already installed but attributes deleted — attributes get healed", () => {
+    const target = resolve(tmp, ".opencode")
+    mkdirSync(target, { recursive: true })
+    writeFileSync(resolve(target, ".engram-version.jsonc"), JSON.stringify({ version: "0.9.0" }))
+
+    // First extract — installs everything
+    selfExtract(pkg, tmp, "1.0.2")
+    expect(readFileSync(resolve(tmp, ".git", "info", "attributes"), "utf-8")).toContain("AGENTS.md filter=engram")
+
+    // Simulate user deleting attributes
+    const attrsPath = resolve(tmp, ".git", "info", "attributes")
+    const { unlinkSync, chmodSync } = require("node:fs")
+    unlinkSync(attrsPath)
+
+    // Version bump — trigger second extract
+    writeFileSync(resolve(target, ".engram-version.jsonc"), JSON.stringify({ version: "0.9.1" }))
+    selfExtract(pkg, tmp, "1.0.3")
+
+    // Attributes should be healed
+    expect(existsSync(attrsPath)).toBe(true)
+    expect(readFileSync(attrsPath, "utf-8")).toContain("AGENTS.md filter=engram")
+  })
+
+  it("logger receives CLAUDE.md warning when CLAUDE.md exists", () => {
+    const target = resolve(tmp, ".opencode")
+    mkdirSync(target, { recursive: true })
+    writeFileSync(resolve(target, ".engram-version.jsonc"), JSON.stringify({ version: "0.9.0" }))
+    writeFileSync(resolve(tmp, "CLAUDE.md"), "# rules\nSENTINEL\n")
+
+    const messages: string[] = []
+    selfExtract(pkg, tmp, "1.0.2", (m: string) => messages.push(m))
+
+    expect(messages.some((m) => m.includes("WARNING") && m.includes("CLAUDE.md"))).toBe(true)
+  })
+})
+
+describe("filter scripts", () => {
+  const scriptsDir = resolve(__dirname, "..", "scripts")
+
+  it("opencode-engram-clean strips the Engram block", () => {
+    const input = `<!-- engram v1.0.0 -->
+# block content
+<!-- /engram -->
+user content
+`
+    const result = execSync(`python3 ${resolve(scriptsDir, "opencode-engram-clean")}`, { input })
+    expect(result.toString()).toBe("user content\n")
+  })
+
+  it("opencode-engram-clean passes through content without a block", () => {
+    const input = "just user content\n"
+    const result = execSync(`python3 ${resolve(scriptsDir, "opencode-engram-clean")}`, { input })
+    expect(result.toString()).toBe(input)
+  })
+
+  it("opencode-engram-clean strips block-only content to empty", () => {
+    const input = `<!-- engram v1.0.0 -->
+# block content
+<!-- /engram -->
+`
+    const result = execSync(`python3 ${resolve(scriptsDir, "opencode-engram-clean")}`, { input })
+    expect(result.toString()).toBe("")
+  })
+
+  it("opencode-engram-clean handles empty stdin", () => {
+    const result = execSync(`python3 ${resolve(scriptsDir, "opencode-engram-clean")}`, { input: "" })
+    expect(result.toString()).toBe("")
+  })
+
+  it("opencode-engram-clean does not strip block without closing marker", () => {
+    const input = `<!-- engram v1.0.0 -->
+# incomplete block
+no close marker
+`
+    const result = execSync(`python3 ${resolve(scriptsDir, "opencode-engram-clean")}`, { input })
+    expect(result.toString()).toBe(input)
+  })
+
+  it("opencode-engram-clean preserves content above the block", () => {
+    const input = `My header
+
+<!-- engram v1.0.0 -->
+# block content
+<!-- /engram -->
+user content
+`
+    const result = execSync(`python3 ${resolve(scriptsDir, "opencode-engram-clean")}`, { input })
+    expect(result.toString()).toBe("My header\n\nuser content\n")
+  })
+
+  it("opencode-engram-clean preserves content above and below the block", () => {
+    const input = `# Header
+custom rule
+
+<!-- engram v1.0.0 -->
+# block
+<!-- /engram -->
+
+# Footer
+more rules
+`
+    const result = execSync(`python3 ${resolve(scriptsDir, "opencode-engram-clean")}`, { input })
+    expect(result.toString()).toBe("# Header\ncustom rule\n\n\n# Footer\nmore rules\n")
+  })
+
+  it("opencode-engram-clean handles CRLF line endings", () => {
+    const input = "<!-- engram v1.0.0 -->\r\n# block content\r\n<!-- /engram -->\r\nuser content\r\n"
+    const result = execSync(`python3 ${resolve(scriptsDir, "opencode-engram-clean")}`, { input })
+    expect(result.toString()).toBe("user content\n")
+  })
+
+  it("opencode-engram-clean handles mixed CRLF and LF line endings", () => {
+    const input = "<!-- engram v1.0.0 -->\r\n# block\r\n<!-- /engram -->\n\nuser content\n"
+    const result = execSync(`python3 ${resolve(scriptsDir, "opencode-engram-clean")}`, { input })
+    expect(result.toString()).toBe("\nuser content\n")
+  })
+
+  it("opencode-engram-smudge prepends block from template", () => {
+    const template = "<!-- engram v1.0.2 -->\n# template\n<!-- /engram -->\n"
+    const tmp = mkdtempSync(resolve(tmpdir(), "engram-test-"))
+    try {
+      mkdirSync(resolve(tmp, ".opencode"), { recursive: true })
+      writeFileSync(resolve(tmp, ".opencode", ".engram-smudge-template"), template)
+      const input = "user content\n"
+      const result = execSync(`python3 ${resolve(scriptsDir, "opencode-engram-smudge")}`, { input, cwd: tmp })
+      expect(result.toString()).toBe(template + input)
+    } finally {
+      rmSync(tmp, { recursive: true })
+    }
+  })
+
+  it("opencode-engram-smudge passes through when template missing", () => {
+    const tmp = mkdtempSync(resolve(tmpdir(), "engram-test-"))
+    try {
+      const input = "user content\n"
+      const result = execSync(`python3 ${resolve(scriptsDir, "opencode-engram-smudge")}`, { input, cwd: tmp })
+      expect(result.toString()).toBe(input)
+    } finally {
+      rmSync(tmp, { recursive: true })
+    }
+  })
+
+  it("opencode-engram-smudge passes through when content already has marker", () => {
+    const template = "<!-- engram v1.0.2 -->\n# template\n<!-- /engram -->\n"
+    const tmp = mkdtempSync(resolve(tmpdir(), "engram-test-"))
+    try {
+      mkdirSync(resolve(tmp, ".opencode"), { recursive: true })
+      writeFileSync(resolve(tmp, ".opencode", ".engram-smudge-template"), template)
+      const input = "<!-- engram v1.0.0 -->\nuser content\n"
+      const result = execSync(`python3 ${resolve(scriptsDir, "opencode-engram-smudge")}`, { input, cwd: tmp })
+      expect(result.toString()).toBe(input)
+    } finally {
+      rmSync(tmp, { recursive: true })
+    }
+  })
+
+  it("opencode-engram-smudge outputs just template when content is empty", () => {
+    const template = "<!-- engram v1.0.2 -->\n# template\n<!-- /engram -->\n"
+    const tmp = mkdtempSync(resolve(tmpdir(), "engram-test-"))
+    try {
+      mkdirSync(resolve(tmp, ".opencode"), { recursive: true })
+      writeFileSync(resolve(tmp, ".opencode", ".engram-smudge-template"), template)
+      const result = execSync(`python3 ${resolve(scriptsDir, "opencode-engram-smudge")}`, { input: "", cwd: tmp })
+      expect(result.toString()).toBe(template)
+    } finally {
+      rmSync(tmp, { recursive: true })
+    }
+  })
+
+  it("opencode-engram-smudge passes through when template is empty", () => {
+    const tmp = mkdtempSync(resolve(tmpdir(), "engram-test-"))
+    try {
+      mkdirSync(resolve(tmp, ".opencode"), { recursive: true })
+      writeFileSync(resolve(tmp, ".opencode", ".engram-smudge-template"), "")
+      const input = "user content\n"
+      const result = execSync(`python3 ${resolve(scriptsDir, "opencode-engram-smudge")}`, { input, cwd: tmp })
+      expect(result.toString()).toBe(input)
+    } finally {
+      rmSync(tmp, { recursive: true })
+    }
+  })
+
+  it("opencode-engram-smudge prepends template to content without trailing newline", () => {
+    const template = "<!-- engram v1.0.2 -->\n# template\n<!-- /engram -->\n"
+    const tmp = mkdtempSync(resolve(tmpdir(), "engram-test-"))
+    try {
+      mkdirSync(resolve(tmp, ".opencode"), { recursive: true })
+      writeFileSync(resolve(tmp, ".opencode", ".engram-smudge-template"), template)
+      const result = execSync(`python3 ${resolve(scriptsDir, "opencode-engram-smudge")}`, { input: "inline content", cwd: tmp })
+      expect(result.toString()).toBe(template + "inline content")
+    } finally {
+      rmSync(tmp, { recursive: true })
+    }
+  })
+})
+
+/**
+ * Real git lifecycle tests.
+ *
+ * These tests execute actual git commands (init, add, commit, show, checkout)
+ * against the installed filter configuration. They catch regressions that
+ * piped-stdin tests cannot: unquoted semicolons in git-config (double-quoting
+ * is required because ; is a comment delimiter), the .git/info/exclude
+ * interaction (exclude bypass via --force), and the smudge restore cycle.
+ *
+ * Skipped gracefully when git is not available on the system.
+ */
+describe("filter lifecycle (real git)", () => {
+  const scriptsDir = resolve(__dirname, "..", "scripts")
+
+  /**
+   * Full-stack test that verifies the complete smudge/clean lifecycle against a
+   * real git repository:
+   *
+   *   1. git init → selfExtract installs the filter
+   *   2. git add --force AGENTS.md  (--force bypasses .git/info/exclude)
+   *   3. git commit
+   *   4. git show HEAD:AGENTS.md   — block must be GONE  (clean)
+   *   5. git checkout -- AGENTS.md  — block must be BACK (smudge)
+   *
+   * Would have caught:
+   *   — unquoted ; truncation in git-config
+   *   — .engram-* leaking through git
+   *   — exclude blocking git add
+   */
+  it("git add+commit strips Engram block, checkout restores it", () => {
+    const repo = mkdtempSync(resolve(tmpdir(), "engram-git-repo-"))
+    try {
+      // Skip if git is not available
+      try { execSync("git --version", { cwd: repo, stdio: "ignore" }) } catch { return }
+
+      execSync("git init", { cwd: repo, stdio: "ignore" })
+      execSync('git config user.email "test@test.com"', { cwd: repo, stdio: "ignore" })
+      execSync('git config user.name "Test"', { cwd: repo, stdio: "ignore" })
+      writeFileSync(resolve(repo, "opencode.jsonc"), "{}")
+
+      const pkg = resolve(repo, "pkg")
+      mkdirSync(resolve(pkg, "skills"), { recursive: true })
+      mkdirSync(resolve(pkg, "agents"), { recursive: true })
+      mkdirSync(resolve(pkg, "scripts"), { recursive: true })
+      writeFileSync(resolve(pkg, "skills", "SKILL.md"), "")
+      writeFileSync(resolve(pkg, "agents", "agent.md"), "")
+      writeFileSync(resolve(pkg, "scripts", "engram.py"), "")
+      writeFileSync(resolve(pkg, "package.json"), JSON.stringify({ version: "1.0.2" }))
+
+      // Copy filter scripts into pkg so selfExtract places them in .opencode/scripts/
+      copyFileSync(resolve(scriptsDir, "opencode-engram-clean"), resolve(pkg, "scripts", "opencode-engram-clean"))
+      copyFileSync(resolve(scriptsDir, "opencode-engram-smudge"), resolve(pkg, "scripts", "opencode-engram-smudge"))
+
+      const target = resolve(repo, ".opencode")
+      mkdirSync(target, { recursive: true })
+      writeFileSync(resolve(target, ".engram-version.jsonc"), JSON.stringify({ version: "0.9.0" }))
+
+      // selfExtract writes AGENTS.md + installs git filter
+      selfExtract(pkg, repo, "1.0.2")
+
+      const agentsMd = resolve(repo, "AGENTS.md")
+      expect(existsSync(agentsMd)).toBe(true)
+
+      const beforeCommit = readFileSync(agentsMd, "utf-8")
+      expect(beforeCommit).toContain("<!-- engram v1.0.2 -->")
+
+      // git add + commit (--force because .git/info/exclude ignores AGENTS.md)
+      execSync("git add --force AGENTS.md", { cwd: repo, stdio: "ignore" })
+      execSync('git commit -m "add AGENTS.md"', { cwd: repo, stdio: "ignore" })
+
+      // git show HEAD:AGENTS.md has NO block (clean filter stripped it)
+      const committed = execSync("git show HEAD:AGENTS.md", { cwd: repo }).toString()
+      expect(committed).not.toContain("<!-- engram v")
+      expect(committed).not.toContain("<!-- /engram -->")
+
+      // git checkout restores the block (smudge filter prepends it)
+      execSync("git checkout -- AGENTS.md", { cwd: repo, stdio: "ignore" })
+      const afterCheckout = readFileSync(agentsMd, "utf-8")
+      expect(afterCheckout).toContain("<!-- engram v1.0.2 -->")
+    } finally {
+      rmSync(repo, { recursive: true })
+    }
+  })
+})

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -74,20 +74,19 @@ describe("pseudo-command registration", () => {
     expect(cfg.command["engram-update"]).toBeDefined()
   })
 
-  it("registers instructions.md path when file exists", async () => {
+  it("does NOT set cfg.instructions for AGENTS.md (native discovery handles it)", async () => {
     const target = resolve(tmp, ".opencode")
     mkdirSync(target, { recursive: true })
-    writeFileSync(resolve(target, "instructions.md"), "test content")
+    writeFileSync(resolve(tmp, "AGENTS.md"), "test content")
 
     const plugin = await getPlugin(tmp)
     const cfg: any = {}
     await plugin.config!(cfg)
 
-    expect(cfg.instructions).toBeDefined()
-    expect(cfg.instructions).toContain(resolve(target, "instructions.md"))
+    expect(cfg.instructions).toBeUndefined()
   })
 
-  it("does NOT set cfg.instructions when instructions.md is absent", async () => {
+  it("does NOT set cfg.instructions when AGENTS.md is absent", async () => {
     const plugin = await getPlugin(tmp)
     const cfg: any = {}
     await plugin.config!(cfg)

--- a/__tests__/install.test.ts
+++ b/__tests__/install.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest"
 import { tmpdir } from "node:os"
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync } from "node:fs"
 import { resolve } from "node:path"
-import { getExtractTarget, needsExtract, readPrevVersion, copyMissing, selfExtract, getVERSION } from "../.opencode/install"
+import { getExtractTarget, needsExtract, readPrevVersion, copyMissing, selfExtract, getVERSION, resolveAgentsPath, writeOrPrependAgentsMd } from "../.opencode/install"
 
 describe("getExtractTarget", () => {
   let tmp: string
@@ -171,4 +171,194 @@ describe("selfExtract — engram-update is never written to disk", () => {
     expect(existsSync(resolve(target, ".engram-update.jsonc"))).toBe(false)
   })
 
+  it("removes legacy instructions.md on version bump", () => {
+    const target = resolve(tmp, ".opencode")
+    mkdirSync(target, { recursive: true })
+    writeFileSync(resolve(target, ".engram-version.jsonc"), JSON.stringify({ version: "0.9.0" }))
+    writeFileSync(resolve(target, "instructions.md"), "legacy content")
+
+    selfExtract(pkg, tmp, "1.0.2")
+    expect(existsSync(resolve(target, "instructions.md"))).toBe(false)
+  })
+
+  it("writes .engram-smudge-template on extract", () => {
+    const target = resolve(tmp, ".opencode")
+    mkdirSync(target, { recursive: true })
+
+    selfExtract(pkg, tmp, "1.0.2")
+    const tmpl = resolve(target, ".engram-smudge-template")
+    expect(existsSync(tmpl)).toBe(true)
+    expect(readFileSync(tmpl, "utf-8")).toContain("<!-- engram v1.0.2 -->")
+    expect(readFileSync(tmpl, "utf-8")).toContain("<!-- /engram -->")
+  })
+
+})
+
+describe("resolveAgentsPath", () => {
+  it("returns project root for project-level target", () => {
+    expect(resolveAgentsPath(resolve("/project", ".opencode"))).toBe(resolve("/project", "AGENTS.md"))
+  })
+
+  it("returns inside target for global target", () => {
+    expect(resolveAgentsPath(resolve("/home/u", ".config", "opencode"))).toBe(resolve("/home/u", ".config", "opencode", "AGENTS.md"))
+  })
+})
+
+describe("writeOrPrependAgentsMd", () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = mkdtempSync(resolve(tmpdir(), "engram-test-"))
+    writeFileSync(resolve(tmp, "opencode.jsonc"), "{}")
+  })
+  afterEach(() => rmSync(tmp, { recursive: true }))
+
+  function projectTarget() { return resolve(tmp, ".opencode") }
+  function agentsPath() { return resolve(tmp, "AGENTS.md") }
+
+  it("creates AGENTS.md with versioned marker block when file does not exist", () => {
+    writeOrPrependAgentsMd(projectTarget(), "1.0.0")
+    expect(existsSync(agentsPath())).toBe(true)
+    const content = readFileSync(agentsPath(), "utf-8")
+    expect(content).toContain("<!-- engram v1.0.0 -->")
+    expect(content).toContain("<!-- /engram -->")
+    expect(content).toContain("Engram — Evidence-Based Learning Engine")
+  })
+
+  it("is no-op when file already has the same version marker", () => {
+    writeOrPrependAgentsMd(projectTarget(), "1.0.0")
+    const content1 = readFileSync(agentsPath(), "utf-8")
+    writeOrPrependAgentsMd(projectTarget(), "1.0.0")
+    const content2 = readFileSync(agentsPath(), "utf-8")
+    expect(content1).toBe(content2)
+  })
+
+  it("replaces old block and preserves user content on version bump", () => {
+    writeOrPrependAgentsMd(projectTarget(), "1.0.0")
+    writeFileSync(agentsPath(), readFileSync(agentsPath(), "utf-8") + "\n\nMy custom rule.")
+
+    writeOrPrependAgentsMd(projectTarget(), "1.0.1")
+    const content = readFileSync(agentsPath(), "utf-8")
+    expect(content).toContain("<!-- engram v1.0.1 -->")
+    expect(content).toContain("My custom rule.")
+    expect(content).not.toContain("<!-- engram v1.0.0 -->")
+  })
+
+  it("prepends block at top when no marker exists, preserving existing content", () => {
+    writeFileSync(agentsPath(), "Existing user rules.")
+
+    writeOrPrependAgentsMd(projectTarget(), "1.0.0")
+    const content = readFileSync(agentsPath(), "utf-8")
+    expect(content.startsWith("<!-- engram v1.0.0 -->")).toBe(true)
+    expect(content).toContain("Existing user rules.")
+  })
+
+  it("handles multiple version bumps", () => {
+    writeOrPrependAgentsMd(projectTarget(), "1.0.0")
+    writeOrPrependAgentsMd(projectTarget(), "1.0.1")
+    writeOrPrependAgentsMd(projectTarget(), "2.0.0")
+    const content = readFileSync(agentsPath(), "utf-8")
+    expect(content).toContain("<!-- engram v2.0.0 -->")
+    expect(content).not.toContain("<!-- engram v1.0.0 -->")
+    expect(content).not.toContain("<!-- engram v1.0.1 -->")
+  })
+
+  it("writes AGENTS.md at correct global location", () => {
+    const globalTarget = resolve(tmp, ".config", "opencode")
+    mkdirSync(globalTarget, { recursive: true })
+    writeOrPrependAgentsMd(globalTarget, "1.0.0")
+    expect(existsSync(resolve(globalTarget, "AGENTS.md"))).toBe(true)
+  })
+
+  it("preserves content with special characters below the block", () => {
+    writeOrPrependAgentsMd(projectTarget(), "1.0.0")
+    writeFileSync(agentsPath(), readFileSync(agentsPath(), "utf-8") + "\n\n## My Rules\n- rule 1\n- rule 2\n\n```json\n{\"key\": \"value\"}\n```")
+
+    writeOrPrependAgentsMd(projectTarget(), "1.0.1")
+    const content = readFileSync(agentsPath(), "utf-8")
+    expect(content).toContain("<!-- engram v1.0.1 -->")
+    expect(content).toContain("## My Rules")
+    expect(content).toContain("```json")
+    expect(content).toContain('"key"')
+  })
+
+  it("handles empty existing file", () => {
+    writeFileSync(agentsPath(), "")
+    writeOrPrependAgentsMd(projectTarget(), "1.0.0")
+    const content = readFileSync(agentsPath(), "utf-8")
+    expect(content).toContain("<!-- engram v1.0.0 -->")
+    expect(content).not.toMatch(/\n\n$/)
+  })
+
+  it("handles whitespace-only existing file", () => {
+    writeFileSync(agentsPath(), " \n\n  \t  ")
+    writeOrPrependAgentsMd(projectTarget(), "1.0.0")
+    const content = readFileSync(agentsPath(), "utf-8")
+    expect(content.startsWith("<!-- engram v1.0.0 -->")).toBe(true)
+  })
+
+  it("prepends when close marker exists without opening marker", () => {
+    writeFileSync(agentsPath(), "<!-- /engram -->\norphan close marker")
+    writeOrPrependAgentsMd(projectTarget(), "1.0.0")
+    const content = readFileSync(agentsPath(), "utf-8")
+    expect(content.startsWith("<!-- engram v1.0.0 -->")).toBe(true)
+    expect(content).toContain("orphan close marker")
+  })
+
+  it("prepends when opening marker exists without matching close marker", () => {
+    writeFileSync(agentsPath(), "<!-- engram v0.9.0 -->\n# incomplete block\nno close marker")
+    writeOrPrependAgentsMd(projectTarget(), "1.0.0")
+    const content = readFileSync(agentsPath(), "utf-8")
+    expect(content.startsWith("<!-- engram v1.0.0 -->")).toBe(true)
+    expect(content).toContain("<!-- engram v0.9.0 -->")
+    expect(content).toContain("no close marker")
+  })
+
+  it("writes to same dir when target basename is not .opencode", () => {
+    const t = resolve(tmp, "custom-dir")
+    mkdirSync(t, { recursive: true })
+    writeOrPrependAgentsMd(t, "1.0.0")
+    expect(existsSync(resolve(t, "AGENTS.md"))).toBe(true)
+  })
+
+  it("handles semver versions with pre-release tags", () => {
+    writeOrPrependAgentsMd(projectTarget(), "1.0.0-alpha.1")
+    const content = readFileSync(agentsPath(), "utf-8")
+    expect(content).toContain("<!-- engram v1.0.0-alpha.1 -->")
+  })
+
+  it("replaces block and preserves user content with leading blank lines", () => {
+    writeOrPrependAgentsMd(projectTarget(), "1.0.0")
+    writeFileSync(agentsPath(), readFileSync(agentsPath(), "utf-8") + "\n\n\n\nUser content after blank lines.")
+
+    writeOrPrependAgentsMd(projectTarget(), "1.0.1")
+    const content = readFileSync(agentsPath(), "utf-8")
+    expect(content).toContain("<!-- engram v1.0.1 -->")
+    expect(content).toContain("User content after blank lines.")
+    expect(content).not.toMatch(/\n\n\n\nUser content/)
+  })
+
+  it("does not introduce double newlines when user content follows immediately after close marker", () => {
+    writeOrPrependAgentsMd(projectTarget(), "1.0.0")
+    const raw = readFileSync(agentsPath(), "utf-8")
+    writeFileSync(agentsPath(), raw.replace(/\n$/, "") + "\nuser content")
+
+    writeOrPrependAgentsMd(projectTarget(), "1.0.1")
+    const content = readFileSync(agentsPath(), "utf-8")
+    expect(content).toContain("<!-- /engram -->")
+    expect(content).toContain("user content")
+  })
+
+  it("preserves content above the marker on replace", () => {
+    writeOrPrependAgentsMd(projectTarget(), "1.0.0")
+    const raw = readFileSync(agentsPath(), "utf-8")
+    writeFileSync(agentsPath(), "User header above.\n" + raw + "\n\nFooter below.")
+
+    writeOrPrependAgentsMd(projectTarget(), "1.0.1")
+    const content = readFileSync(agentsPath(), "utf-8")
+    expect(content).toContain("User header above.")
+    expect(content).toContain("Footer below.")
+    expect(content).toContain("<!-- engram v1.0.1 -->")
+    expect(content).not.toContain("<!-- engram v1.0.0 -->")
+  })
 })

--- a/scripts/opencode-engram-clean
+++ b/scripts/opencode-engram-clean
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""
+Git clean filter for AGENTS.md — strips the Engram block before staging.
+
+Used by the git smudge/clean filter pair installed by selfExtract.
+Reads stdin, removes the <!-- engram v{...} --> ... <!-- /engram --> block,
+and writes the result to stdout. No-op if no block is present.
+
+Note: CRLF (\r\n) is normalized to LF (\n) across the entire file, not just
+the block. In practice this is harmless — git's autocrlf converts back on
+checkout — but it does mean the clean filter rewrites line endings in user
+content below the block too.
+"""
+import os
+import re
+import sys
+
+MARKER_RE = re.compile(
+    r"^<!-- engram v.+? -->\n(?:.*?\n)*?^<!-- /engram -->\n?",
+    re.MULTILINE | re.DOTALL,
+)
+
+content = sys.stdin.read()
+# Normalize CRLF to LF so the regex works on Windows
+if "\r\n" in content:
+    content = content.replace("\r\n", "\n")
+sys.stdout.write(MARKER_RE.sub("", content))

--- a/scripts/opencode-engram-smudge
+++ b/scripts/opencode-engram-smudge
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""
+Git smudge filter for AGENTS.md — prepends the Engram block on checkout.
+
+Reads stdin (git-stored content, without the Engram block), reads the
+block template from .opencode/.engram-smudge-template, prepends it,
+and writes to stdout. No-op if template doesn't exist or block already
+present.
+"""
+import os
+import sys
+
+TEMPLATE_PATH = os.path.join(".opencode", ".engram-smudge-template")
+
+content = sys.stdin.read()
+if "<!-- engram v" in content:
+    sys.stdout.write(content)
+    sys.exit(0)
+
+if not os.path.isfile(TEMPLATE_PATH):
+    sys.stdout.write(content)
+    sys.exit(0)
+
+with open(TEMPLATE_PATH, encoding="utf-8") as fh:
+    template = fh.read()
+
+if template:
+    result = template + content if content else template
+    sys.stdout.write(result)
+else:
+    sys.stdout.write(content)


### PR DESCRIPTION
### Summary

Replace `.opencode/instructions.md` (always overwritten on version bump)
with `AGENTS.md` at project root (or `~/.config/opencode/`), using a
versioned marker block (`<!-- engram v{VERSION} -->` / `<!-- /engram -->`).

### V1 vs V2 architecture

OpenCode has two parallel session execution paths:

| Path | Consumer | Reads `cfg.instructions`? | Discovers AGENTS.md? |
|---|---|---|---|
| **V1/Compat** | Desktop HTTP API, CLI, GitHub Action | Yes (Instruction.Service) | Yes (findUp walk) |
| **V2 SessionRunner** | Future (not yet in production) | No (SystemContext) | Yes (InstructionContext) |

The old `instructions.md` inside `.opencode/` worked exclusively via
`cfg.instructions` — only on V1/Compat. AGENTS.md works on both paths:
V1 discovers it via `findUp`, V2 via `InstructionContext`. No `cfg.instructions`
registration needed — both re-read from disk every request.

### Versioned marker behavior — `writeOrPrependAgentsMd`
| Scenario | Action |
|---|---|
| AGENTS.md doesn't exist | Create full block with `<!-- engram v{VERSION} -->` |
| Same version marker present | No-op (idempotent) |
| Different version marker | Replace old block, preserve user content below |
| No marker found | Prepend block at top, preserve existing content |

### Git lifecycle — three local mechanisms
All written to `.git/` (not versioned, clone-local, idempotent):

| Mechanism | Location | Role |
|---|---|---|
| clean filter | `.git/config` | Strips Engram block on `git add` |
| smudge filter | `.git/config` | Restores block on `git checkout` |
| path attributes | `.git/info/attributes` | Assigns `filter=engram` to AGENTS.md |
| local exclude | `.git/info/exclude` | Prevents tracking of otherwise-empty AGENTS.md and `.engram-*` files |

Guarded: if the scripts don't exist (no plugin installed), the filter
falls back to `cat` — harmless passthrough. Installs skipped with a
warning when `python3` is not on PATH. Only runs for project-level
installs (where `.git/config` exists).

### CLAUDE.md collision
AGENTS.md at project root takes priority over CLAUDE.md in instruction
discovery (first filename match wins). `selfExtract` logs a visible
warning via `warnClaudeMdCollision()` when CLAUDE.md exists.

### Logger
`createPluginLogger(client)` writes structured logs via `client.app.log()`
and shows TUI toasts for warnings — extracted to `.opencode/logger.ts`.

### Changes
| File | Change |
|---|---|
| `scripts/opencode-engram-clean` | **New** — git clean filter (strip block, normalize CRLF) |
| `scripts/opencode-engram-smudge` | **New** — git smudge filter (prepend block from template) |
| `.opencode/install.ts` | `resolveAgentsPath`, `writeOrPrependAgentsMd`, `installGitFilter`, `buildEngramBlock`, `findEngramBlock`, `python3` probe |
| `.opencode/index.ts` | UPDATE_TEMPLATE updated, `cfg.instructions` push removed |
| `.opencode/logger.ts` | **New** — `createPluginLogger(client)` |
| `.opencode/claude-warning.ts` | **New** — CLAUDE.md collision warning |
| `.opencode/.gitignore` | Removed `instructions.md` entry |
| `__tests__/install.test.ts` | 36 tests (extraction, versioning, marker) |
| `__tests__/git-filter.test.ts` | **New** — 20 tests (filter, exclude, clean/smudge scripts, real git lifecycle) |
| `__tests__/claude-warning.test.ts` | **New** — 8 tests (collision warning) |
| `__tests__/index.test.ts` | Updated `instructions.md` → `AGENTS.md` |

### Testing
- `vitest`: 142 pass (was 88) — 4 new test files
- `python3 scripts/engram.py selftest`: 217/217 pass
- `npx tsc --noEmit`: clean