### PR TITLE
Cloud-Setup: Engram in Claude Code on the web nutzbar machen

### DIFF
--- a/.claude/agents/engram-artifact-smith.md
+++ b/.claude/agents/engram-artifact-smith.md
@@ -1,0 +1,1 @@
+../../agents/engram-artifact-smith.md

--- a/.claude/agents/engram-assessor.md
+++ b/.claude/agents/engram-assessor.md
@@ -1,0 +1,1 @@
+../../agents/engram-assessor.md

--- a/.claude/agents/engram-curriculum-architect.md
+++ b/.claude/agents/engram-curriculum-architect.md
@@ -1,0 +1,1 @@
+../../agents/engram-curriculum-architect.md

--- a/.claude/hooks/engram-env.sh
+++ b/.claude/hooks/engram-env.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Shared resolver for the cloud setup: finds the Engram checkout and the private
+# state repo. Sourced by session-start.sh and engram-save.sh — never run directly.
+#
+# Sets, when it can:
+#   ENGRAM_PROJECT  absolute path of this engram checkout
+#   ENGRAM_STATE    absolute path of the engram-learning checkout (state repo)
+#   ENGRAM_HOME     $ENGRAM_STATE/learning  — what engram.py reads
+#
+# Leaves ENGRAM_STATE empty when the state repo isn't attached to the session.
+# Callers must handle that: learning state then lives in the container only and
+# dies with it.
+
+# --- the engram checkout ------------------------------------------------------
+ENGRAM_PROJECT="${CLAUDE_PROJECT_DIR:-}"
+if [ -z "$ENGRAM_PROJECT" ] || [ ! -f "$ENGRAM_PROJECT/scripts/engram.py" ]; then
+  ENGRAM_PROJECT="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")/../.." 2>/dev/null && pwd)"
+fi
+
+# --- the state repo -----------------------------------------------------------
+# First hit wins. ENGRAM_STATE_REPO is the escape hatch for a non-standard clone.
+ENGRAM_STATE=""
+for _c in "${ENGRAM_STATE_REPO:-}" \
+          "$ENGRAM_PROJECT/../engram-learning" \
+          "/home/user/engram-learning" \
+          "$HOME/engram-learning"; do
+  [ -n "$_c" ] || continue
+  if [ -d "$_c/.git" ]; then
+    ENGRAM_STATE="$(CDPATH= cd -- "$_c" 2>/dev/null && pwd)"
+    break
+  fi
+done
+unset _c
+
+if [ -n "$ENGRAM_STATE" ]; then
+  ENGRAM_HOME="$ENGRAM_STATE/learning"
+fi

--- a/.claude/hooks/engram-save.sh
+++ b/.claude/hooks/engram-save.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Stop hook — persists the learning state.
+#
+# Without this, everything Engram records dies with the container. Runs at the end
+# of every turn: commits and pushes the private engram-learning repo when it has
+# changes, silent no-op when it doesn't.
+#
+# MUST NEVER BLOCK A TURN — every path ends in exit 0.
+set -u
+
+HOOK_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+# shellcheck source=engram-env.sh
+. "$HOOK_DIR/engram-env.sh" 2>/dev/null || exit 0
+
+# No state repo attached — session-start.sh already said so; don't nag every turn.
+[ -n "$ENGRAM_STATE" ] || exit 0
+[ -d "$ENGRAM_HOME" ] || exit 0
+
+cd "$ENGRAM_STATE" 2>/dev/null || exit 0
+
+# Nothing changed under learning/ → nothing to do.
+if [ -z "$(git status --porcelain -- learning 2>/dev/null)" ]; then
+  exit 0
+fi
+
+# Identity fallback: the remote environment normally sets this, but a missing
+# identity would make the commit fail and silently lose the session's work.
+git config user.name  >/dev/null 2>&1 || git config user.name  "Engram Cloud"
+git config user.email >/dev/null 2>&1 || git config user.email "engram@localhost"
+
+# A message that says what actually changed, read straight from the engine.
+SUMMARY="$(ENGRAM_HOME="$ENGRAM_HOME" python3 "$ENGRAM_PROJECT/scripts/engram.py" doctor 2>/dev/null \
+  | python3 -c 'import json,sys
+try:
+    d = json.load(sys.stdin)
+    print("%s Themen, %s Konzepte, %s Receipts" % (d.get("topics",0), d.get("nodes",0), d.get("receipts",0)))
+except Exception:
+    print("Lernstand aktualisiert")' 2>/dev/null)"
+[ -n "$SUMMARY" ] || SUMMARY="Lernstand aktualisiert"
+
+git add -A -- learning >/dev/null 2>&1
+git commit -q -m "engram: $SUMMARY" >/dev/null 2>&1 || exit 0
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+[ -n "$BRANCH" ] && [ "$BRANCH" != "HEAD" ] || BRANCH=main
+
+# Network flakiness is the expected failure here, so back off and retry.
+for delay in 2 4 8 16 0; do
+  if git push -u origin "$BRANCH" >/dev/null 2>&1; then
+    exit 0
+  fi
+  [ "$delay" = "0" ] && break
+  sleep "$delay"
+done
+
+echo "engram: Lernstand committet, aber der Push nach engram-learning ist fehlgeschlagen."
+echo "engram: Bitte 'git -C $ENGRAM_STATE push -u origin $BRANCH' ausführen, sonst geht der Stand verloren."
+exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SessionStart hook — makes Engram usable in Claude Code on the web.
+#
+#   1. points ENGRAM_HOME at the private state repo, so the learning state
+#      survives the container being reclaimed
+#   2. runs `engram.py init` (idempotent)
+#   3. surfaces due reviews — Engram's own two-line nudge, silent when nothing
+#      is due
+#   4. installs node deps so `bun run test` / `npx tsc --noEmit` work
+#
+# Runs synchronously: the due nudge has to be on screen before the first turn.
+# MUST NEVER FAIL A SESSION — every path ends in exit 0.
+set -u
+
+HOOK_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+# shellcheck source=engram-env.sh
+. "$HOOK_DIR/engram-env.sh" 2>/dev/null || exit 0
+
+[ -f "$ENGRAM_PROJECT/scripts/engram.py" ] || exit 0
+command -v python3 >/dev/null 2>&1 || {
+  echo "engram: python3 fehlt — die Engine kann nicht laufen."
+  exit 0
+}
+
+# --- 1. state location --------------------------------------------------------
+if [ -n "$ENGRAM_STATE" ]; then
+  mkdir -p "$ENGRAM_HOME" 2>/dev/null
+  export ENGRAM_HOME
+  [ -n "${CLAUDE_ENV_FILE:-}" ] && echo "export ENGRAM_HOME=\"$ENGRAM_HOME\"" >> "$CLAUDE_ENV_FILE"
+else
+  # Loud on purpose. Silent data loss is the worst outcome here: the learner
+  # would do the work and lose the schedule that work was for.
+  echo "engram: WARNUNG — das private State-Repo (engram-learning) ist dieser Session nicht angehängt."
+  echo "engram: Der Lernstand liegt nur im Container und ist nach dessen Ablauf weg. Siehe CLAUDE.md."
+fi
+
+# --- 2./3. init + due nudge ---------------------------------------------------
+# The engine prints upstream's command spelling (/learn, /review, /coach). Here the
+# skills are namespaced to avoid colliding with the global `learn` skill and with
+# Claude Code's built-in /review, so rewrite the names on the way out rather than
+# patching upstream code — that keeps `git merge upstream/main` conflict-free.
+python3 "$ENGRAM_PROJECT/scripts/engram.py" init >/dev/null 2>&1
+python3 "$ENGRAM_PROJECT/scripts/engram.py" session-start 2>/dev/null \
+  | sed -E 's#/(learn|review|coach)\b#/engram-\1#g' || true
+
+# --- 4. node deps (non-fatal; the container image caches this) -----------------
+# --no-save: bun.lock is currently out of sync with package.json upstream, and a
+# rewrite would leave every session with a dirty tree and a future merge conflict.
+if [ ! -d "$ENGRAM_PROJECT/node_modules" ] && command -v bun >/dev/null 2>&1; then
+  (cd "$ENGRAM_PROJECT" && bun install --no-save --silent) >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh\"",
+            "timeout": 120
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/engram-save.sh\"",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/engram-coach/SKILL.md
+++ b/.claude/skills/engram-coach/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: engram-coach
+description: Learning telemetry, strategy, and schedule — retention stats, calibration, grader audit, n-of-1 experiments, HTML dashboard. Use for "how am I doing", weekly check-ins, strategy questions, auditing the grader, or adjusting how Engram teaches.
+argument-hint: [dashboard | audit | experiment | refit | schedule]
+---
+
+# Engram — the adaptation loop
+
+This is a thin alias. The real skill is `skills/coach/SKILL.md` in this repository —
+kept unmodified so upstream updates (`git merge upstream/main`) never conflict.
+
+**Do this now, before anything else:**
+
+1. Resolve the repo root: `git rev-parse --show-toplevel` (or `$CLAUDE_PROJECT_DIR`).
+2. **Read `<root>/skills/coach/SKILL.md` in full.**
+3. Follow it verbatim, from its first instruction — including the engine-resolver
+   bash block, which must be run as written and not replaced by a guessed path.
+
+Do not summarize, paraphrase, or shortcut that file. It is the skill; this file is
+only a stable, collision-free name for it.
+
+**Cloud specifics for this repository** — read `<root>/CLAUDE.md` for the full rules:
+
+- `ENGRAM_HOME` points into the private `engram-learning` checkout, not
+  `~/.claude/learning`. Take the real path from `python3 "$ENGRAM" doctor` (`home`
+  field) and never print `~/.claude/learning` literally.
+- `coach dashboard` writes `artifacts/dashboard.html` inside that checkout. In this
+  cloud environment there is no browser: after generating it, offer to send the file
+  to the user or publish it, rather than telling them to "open it locally".
+- Learning state only survives this container if it is committed and pushed to the
+  `engram-learning` repo. The Stop hook does that automatically; if it reports a
+  failure, push manually before the session ends.

--- a/.claude/skills/engram-learn/SKILL.md
+++ b/.claude/skills/engram-learn/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: engram-learn
+description: Learn any topic properly — first-principles curriculum, generation-first tutoring, verified free recall, FSRS scheduling. Use when the user wants to learn, understand, study, or continue studying something.
+argument-hint: <topic> | continue
+---
+
+# Engram — the acquisition loop
+
+This is a thin alias. The real skill is `skills/learn/SKILL.md` in this repository —
+kept unmodified so upstream updates (`git merge upstream/main`) never conflict.
+
+**Do this now, before anything else:**
+
+1. Resolve the repo root: `git rev-parse --show-toplevel` (or `$CLAUDE_PROJECT_DIR`).
+2. **Read `<root>/skills/learn/SKILL.md` in full.**
+3. Follow it verbatim, from its first instruction — including the engine-resolver
+   bash block, which must be run as written and not replaced by a guessed path.
+
+Do not summarize, paraphrase, or shortcut that file. It is the skill; this file is
+only a name that does not collide with the user's global `learn` skill.
+
+**Cloud specifics for this repository** — read `<root>/CLAUDE.md` for the full rules:
+
+- `ENGRAM_HOME` points into the private `engram-learning` checkout, not
+  `~/.claude/learning`. Take the real path from `python3 "$ENGRAM" doctor` (`home`
+  field) and never print `~/.claude/learning` literally.
+- Learning state only survives this container if it is committed and pushed to the
+  `engram-learning` repo. The Stop hook does that automatically; if it reports a
+  failure, push manually before the session ends.
+- Never put learner free-text on a shell command line. Write JSON with the Write
+  tool and pass `--file`, or pipe to `--json -` / `--production-file -`.

--- a/.claude/skills/engram-review/SKILL.md
+++ b/.claude/skills/engram-review/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: engram-review
+description: Clear due memory reviews with free recall — the two-minute habit that makes learning permanent. Use when reviews are due, or the user wants to review, practice, or "do my engram reviews".
+argument-hint: [quick | <topic>]
+---
+
+# Engram — the retention loop
+
+This is a thin alias. The real skill is `skills/review/SKILL.md` in this repository —
+kept unmodified so upstream updates (`git merge upstream/main`) never conflict.
+
+**Do this now, before anything else:**
+
+1. Resolve the repo root: `git rev-parse --show-toplevel` (or `$CLAUDE_PROJECT_DIR`).
+2. **Read `<root>/skills/review/SKILL.md` in full.**
+3. Follow it verbatim, from its first instruction — including the engine-resolver
+   bash block, which must be run as written and not replaced by a guessed path.
+
+Do not summarize, paraphrase, or shortcut that file. It is the skill; this file is
+only a name that does not collide with Claude Code's built-in `/review`
+(GitHub pull-request review), which stays reachable under its own name.
+
+**Cloud specifics for this repository** — read `<root>/CLAUDE.md` for the full rules:
+
+- `ENGRAM_HOME` points into the private `engram-learning` checkout, not
+  `~/.claude/learning`. Take the real path from `python3 "$ENGRAM" doctor` (`home`
+  field) and never print `~/.claude/learning` literally.
+- Learning state only survives this container if it is committed and pushed to the
+  `engram-learning` repo. The Stop hook does that automatically; if it reports a
+  failure, push manually before the session ends.
+- Never put learner free-text on a shell command line. Write JSON with the Write
+  tool and pass `--file`, or pipe to `--json -` / `--production-file -`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# Engram — Cloud-Setup (Claude Code im Web)
+
+Dieses Repo ist ein Fork von [nagisanzenin/engram](https://github.com/nagisanzenin/engram),
+zusätzlich verdrahtet für die Nutzung in Claude Code on the web. Alles unter `.claude/`
+und diese Datei gehören zum Cloud-Setup; alles andere ist unveränderter Upstream-Code.
+
+## Die drei Kommandos
+
+| Hier | Upstream-Doku | Warum umbenannt |
+|---|---|---|
+| `/engram-learn <topic>` | `/learn` | `learn` kollidiert mit einem globalen Skill des Nutzers |
+| `/engram-review` | `/review` | `review` kollidiert mit Claude Codes GitHub-PR-Review |
+| `/engram-coach` | `/coach` | einheitliches Präfix |
+
+`.claude/skills/engram-*/SKILL.md` sind dünne Aliase: sie enthalten nur Frontmatter
+und die Anweisung, das echte `skills/<name>/SKILL.md` zu lesen und **wörtlich** zu
+befolgen. Die Upstream-Skills bleiben unangetastet — deshalb kollidiert ein Update
+nie. Die Subagents unter `.claude/agents/` sind Symlinks nach `agents/`.
+
+## Lernstand: wo er liegt und warum er gepusht werden muss
+
+Container in dieser Umgebung sind kurzlebig. Der Lernstand überlebt **nur**, wenn er
+nach Git gepusht wird.
+
+- `ENGRAM_HOME` = `<engram-learning-checkout>/learning`, gesetzt vom SessionStart-Hook.
+- Das Repo `karachay-b/engram-learning` ist **privat** — es enthält Freitext-Antworten,
+  Bewertungen und ein Misconception-Log. Es gehört niemals in diesen öffentlichen Fork.
+- Den echten Pfad immer aus `python3 scripts/engram.py doctor` (Feld `home`) lesen.
+  **Nie `~/.claude/learning` wörtlich ausgeben** — hier stimmt das nicht.
+
+Der Stop-Hook (`.claude/hooks/engram-save.sh`) committet und pusht automatisch nach
+jedem Turn. Meldet er einen fehlgeschlagenen Push, muss der Push manuell nachgeholt
+werden, bevor die Session endet.
+
+### Wenn das State-Repo fehlt
+
+Der SessionStart-Hook warnt sichtbar, wenn kein `engram-learning`-Checkout gefunden
+wurde. Dann gilt für diese Session: **Lernstand ist flüchtig.** Behebung, in dieser
+Reihenfolge:
+
+1. Dauerhaft: `karachay-b/engram-learning` in den Umgebungs-Einstellungen auf
+   claude.ai als zweite Quelle eintragen. Danach wird es bei jedem Container-Start
+   automatisch geklont und ist push-berechtigt.
+2. Für die laufende Session: `add_repo(owner="karachay-b", repo="engram-learning",
+   access="push")` aufrufen, in `/home/user/engram-learning` klonen und
+   `.claude/hooks/session-start.sh` erneut ausführen.
+
+Der Suchpfad des Hooks: `$ENGRAM_STATE_REPO` → `<repo>/../engram-learning` →
+`/home/user/engram-learning` → `$HOME/engram-learning`.
+
+## Sicherheitsregel aus dem Upstream — gilt unverändert
+
+**Niemals Lernertext auf die Kommandozeile.** Freitext (Antworten, Lernziele) erreicht
+die Engine nur über eine Datei oder stdin: JSON mit dem Write-Tool schreiben und
+`--file` übergeben, oder nach `--json -` / `--production-file -` pipen. Ein `'` oder
+`$(…)` in einer Antwort wäre sonst eine Command-Injection.
+
+## Updates vom Entwickler übernehmen
+
+Der Lernstand liegt in einem anderen Repo, und das Cloud-Setup benutzt ausschließlich
+Pfade, die es upstream nicht gibt (`.claude/`, `CLAUDE.md`). Ein Update kann deshalb
+weder Lerndaten überschreiben noch Konflikte auslösen.
+
+```bash
+git remote add upstream https://github.com/nagisanzenin/engram.git   # einmalig
+git fetch upstream
+git merge upstream/main
+python3 scripts/engram.py selftest    # muss 302/302 (oder mehr) bestehen
+```
+
+Alternativ der "Sync fork"-Button auf GitHub. Nach jedem Update den Selftest laufen
+lassen — er ist die Gegenprobe, dass die Engine intakt ist.
+
+Ändert Upstream die Namen oder Frontmatter-Beschreibungen der Skills, müssen die
+`description`-Zeilen in `.claude/skills/engram-*/SKILL.md` nachgezogen werden; sie
+sind die einzige bewusste Duplizierung im Setup.
+
+## Tests
+
+Wie CI (`.github/workflows/test.yml`):
+
+```bash
+bun install && bun run test && npx tsc --noEmit
+python3 scripts/engram.py selftest
+```


### PR DESCRIPTION
Engram ist ein lokales Plugin ohne Server — nutzbar "in der Cloud" heisst hier: in jeder Web-Session sofort verfuegbar, mit einem Lernstand, der das Recyceln des Containers ueberlebt.

- .claude/skills/engram-{learn,review,coach}: duenne Aliase, die das echte skills/<name>/SKILL.md woertlich befolgen. Noetig, weil `learn` mit einem globalen Skill und `review` mit Claude Codes GitHub-PR-Review kollidiert — beide wurden vom Projekt-Skill nicht verdraengt. Upstream bleibt unberuehrt.
- .claude/agents/: Symlinks auf die drei Engram-Subagents.
- .claude/hooks/session-start.sh: setzt ENGRAM_HOME auf das private engram-learning-Repo, initialisiert die Engine und zeigt faellige Reviews. Warnt sichtbar, wenn das State-Repo fehlt — stiller Datenverlust waere das schlechteste Ergebnis. Kommandonamen im Nudge werden nachtraeglich auf die engram-* Schreibweise umgeschrieben, statt Upstream-Code zu patchen.
- .claude/hooks/engram-save.sh: committet und pusht den Lernstand nach jedem Turn, mit Backoff-Retry. Ohne diesen Hook waere das ganze Setup sinnlos.
- CLAUDE.md: Betriebsanleitung inkl. Upstream-Update-Pfad.

Alle neuen Pfade existieren upstream nicht, `git merge upstream/main` bleibt damit konfliktfrei. Verifiziert: selftest 302/302, vitest 164/164, tsc sauber, Hooks end-to-end gegen ein simuliertes State-Repo (Thema angelegt, bewertet, committet, gepusht; Nudge feuert; No-op wenn nichts faellig ist).


Claude-Session: https://claude.ai/code/session_01HhCuTR1ojgyXgnu7gS1JTx